### PR TITLE
Fixes for compatibility with Python 3.10

### DIFF
--- a/src/bag/design/module.py
+++ b/src/bag/design/module.py
@@ -468,7 +468,7 @@ class Module(DesignMaster):
             pin_type = TermType[pin_type]
 
         self._cv.add_pin(new_pin, pin_type.value, sig_type.value)
-        if pin_type.name is 'inout':
+        if pin_type.name == 'inout':
             npin_type = 'inputOutput'
         else:
             npin_type = pin_type.name

--- a/src/bag/simulation/core.py
+++ b/src/bag/simulation/core.py
@@ -132,7 +132,7 @@ class TestbenchManager(abc.ABC):
 
         self._work_dir.mkdir(parents=True, exist_ok=True)
         self._specs: Dict[str, Any] = {k: deepcopy(v) for k, v in specs.items()
-                                       if k is not 'sim_params' and k is not 'env_params'}
+                                       if k != 'sim_params' and k != 'env_params'}
         self._specs['sim_params'] = {k: v for k, v in specs['sim_params'].items()}
         self._specs['env_params'] = {k: v.copy() for k, v in specs.get('env_params', {}).items()}
         self.commit()

--- a/src/bag/simulation/libpsf_simdata.py
+++ b/src/bag/simulation/libpsf_simdata.py
@@ -174,7 +174,7 @@ class LibPSFParser:
             swp_vars, swp_data = parse_sweep_info(swp_info, raw_path, ana_type, sim_env, offset=16)
             ana_dict[ana_type][sim_env] = {
                 'inner_sweep': inner_sweep,
-                'outer_sweep': swp_key is not '',
+                'outer_sweep': swp_key != '',
                 'harmonics': harmonic is not None,
                 'swp_vars': swp_vars,
                 'swp_data': swp_data,

--- a/src/bag/util/immutable.py
+++ b/src/bag/util/immutable.py
@@ -50,7 +50,7 @@ from typing import TypeVar, Any, Generic, Dict, Iterable, Tuple, Union, Optional
 
 import sys
 import bisect
-from collections import Hashable, Mapping, Sequence
+from collections.abc import Hashable, Mapping, Sequence
 
 T = TypeVar('T')
 U = TypeVar('U')


### PR DESCRIPTION
- Hashable, Mapping, Sequence was moved from collections to collections.abc since Python 3.3
- Use == and != for string comparisons instead of is