### PR TITLE
bugfix: fixed floating metal in do_power_fill API

### DIFF
--- a/src/bag/layout/template.py
+++ b/src/bag/layout/template.py
@@ -2669,7 +2669,7 @@ class TemplateBase(DesignMaster):
                       vdd_warrs: Optional[Union[WireArray, List[WireArray]]] = None,
                       vss_warrs: Optional[Union[WireArray, List[WireArray]]] = None, bound_box: Optional[BBox] = None,
                       x_margin: int = 0, y_margin: int = 0, sup_type: str = 'both', flip: bool = False,
-                      uniform_grid: bool = False) -> Tuple[List[WireArray], List[WireArray]]:
+                      uniform_grid: bool = False, touch_edge: bool = True) -> Tuple[List[WireArray], List[WireArray]]:
         """Draw power fill on the given layer. Wrapper around do_multi_power_fill method
         that only returns the VDD and VSS wires.
 
@@ -2695,6 +2695,8 @@ class TemplateBase(DesignMaster):
             draw power fill on a common grid instead of dense packing.
         flip : bool
             true to reverse order of power fill. Default (False) is {VDD, VSS}.
+        touch_edge : bool
+            true to draw power fill to the edge of the bounding box. false to keep a margin of the preset value of track space width. Default is True.
 
         Returns
         -------
@@ -2719,7 +2721,7 @@ class TemplateBase(DesignMaster):
 
         # Run the actual power fill using the multi_power_fill function
         ret_warrs = self.do_multi_power_fill(layer_id, tr_manager, top_lists, bound_box,
-                                             x_margin, y_margin, flip, uniform_grid)
+                                             x_margin, y_margin, flip, uniform_grid, touch_edge)
 
         # Reorganize return values
         if sup_type.lower() == 'both':
@@ -2736,7 +2738,7 @@ class TemplateBase(DesignMaster):
     def do_multi_power_fill(self, layer_id: int, tr_manager: TrackManager,
                             sup_list: List[Union[WireArray, List[WireArray]]], bound_box: Optional[BBox] = None,
                             x_margin: int = 0, y_margin: int = 0, flip: bool = False, uniform_grid: bool = False
-                            ) -> List[List[WireArray]]:
+                            , touch_edge: bool = True) -> List[List[WireArray]]:
         """Draw power fill on the given layer. Accepts as many different supply nets as provided.
 
         Parameters
@@ -2757,6 +2759,8 @@ class TemplateBase(DesignMaster):
             draw power fill on a common grid instead of dense packing.
         flip : bool
             true to reverse order of power fill. Default is False.
+        touch_edge : bool
+            true to draw power fill to the edge of the bounding box. false to keep a margin of the preset value of track space width. Default is True.
 
         Returns
         -------
@@ -2782,8 +2786,12 @@ class TemplateBase(DesignMaster):
             cl, cu = bound_box.xl + fill_w2, bound_box.xh - fill_w2
             lower, upper = bound_box.yl, bound_box.yh
         sep_margin = tr_manager.get_sep(layer_id, ('sup', ''))
-        tr_bot = self.grid.coord_to_track(layer_id, cl, mode=RoundMode.GREATER_EQ)
-        tr_top = self.grid.coord_to_track(layer_id, cu, mode=RoundMode.LESS_EQ)
+        if touch_edge:
+            tr_bot = self.grid.coord_to_track(layer_id, cl, mode=RoundMode.GREATER_EQ)
+            tr_top = self.grid.coord_to_track(layer_id, cu, mode=RoundMode.LESS_EQ)
+        else:
+            tr_bot = self.grid.coord_to_track(layer_id, cl, mode=RoundMode.GREATER) + sep_margin
+            tr_top = self.grid.coord_to_track(layer_id, cu, mode=RoundMode.LESS_EQ) - sep_margin
         trs = self.get_available_tracks(layer_id, tid_lo=tr_bot, tid_hi=tr_top, lower=lower, upper=upper,
                                         width=fill_width, sep=fill_space, sep_margin=sep_margin,
                                         uniform_grid=uniform_grid)

--- a/src/bag/layout/template.py
+++ b/src/bag/layout/template.py
@@ -2782,7 +2782,7 @@ class TemplateBase(DesignMaster):
             cl, cu = bound_box.xl + fill_w2, bound_box.xh - fill_w2
             lower, upper = bound_box.yl, bound_box.yh
         sep_margin = tr_manager.get_sep(layer_id, ('sup', ''))
-        tr_bot = self.grid.coord_to_track(layer_id, cl, mode=RoundMode.GREATER_EQ)
+        tr_bot = self.grid.coord_to_track(layer_id, cl, mode=RoundMode.GREATER)
         tr_top = self.grid.coord_to_track(layer_id, cu, mode=RoundMode.LESS_EQ)
         trs = self.get_available_tracks(layer_id, tid_lo=tr_bot, tid_hi=tr_top, lower=lower, upper=upper,
                                         width=fill_width, sep=fill_space, sep_margin=sep_margin,

--- a/src/bag/layout/template.py
+++ b/src/bag/layout/template.py
@@ -2666,11 +2666,10 @@ class TemplateBase(DesignMaster):
             cnt += 1
 
     def do_power_fill(self, layer_id: int, tr_manager: TrackManager,
-                      vdd_warrs: Optional[Union[WireArray,
-                                                List[WireArray]]] = None,
+                      vdd_warrs: Optional[Union[WireArray, List[WireArray]]] = None,
                       vss_warrs: Optional[Union[WireArray, List[WireArray]]] = None, bound_box: Optional[BBox] = None,
                       x_margin: int = 0, y_margin: int = 0, sup_type: str = 'both', flip: bool = False,
-                      uniform_grid: bool = False, touch_edge: bool = True) -> Tuple[List[WireArray], List[WireArray]]:
+                      uniform_grid: bool = False, draw_on_edge: bool = True) -> Tuple[List[WireArray], List[WireArray]]:
         """Draw power fill on the given layer. Wrapper around do_multi_power_fill method
         that only returns the VDD and VSS wires.
 
@@ -2696,7 +2695,7 @@ class TemplateBase(DesignMaster):
             draw power fill on a common grid instead of dense packing.
         flip : bool
             true to reverse order of power fill. Default (False) is {VDD, VSS}.
-        touch_edge : bool
+        draw_on_edge : bool
             true to draw power fill to the edge of the bounding box. false to keep a margin of the preset value of track space width. Default is True.
 
         Returns
@@ -2706,11 +2705,9 @@ class TemplateBase(DesignMaster):
         """
         # Value checks
         if sup_type.lower() not in ['vdd', 'vss', 'both']:
-            raise ValueError(
-                'sup_type has to be "VDD" or "VSS" or "both"(default)')
+            raise ValueError('sup_type has to be "VDD" or "VSS" or "both"(default)')
         if not vdd_warrs and not vss_warrs:
-            raise ValueError(
-                'At least one of vdd_warrs or vss_warrs must be given.')
+            raise ValueError('At least one of vdd_warrs or vss_warrs must be given.')
 
         # Build supply lists based on specficiation
         if sup_type.lower() == 'both' and vdd_warrs and vss_warrs:
@@ -2720,17 +2717,14 @@ class TemplateBase(DesignMaster):
         elif sup_type.lower() == 'vdd' and vdd_warrs:
             top_lists = [vdd_warrs]
         else:
-            raise RuntimeError(
-                'Provided supply type and supply wires do not match.')
+            raise RuntimeError('Provided supply type and supply wires do not match.')
 
         # Run the actual power fill using the multi_power_fill function
-        ret_warrs = self.do_multi_power_fill(layer_id, tr_manager, top_lists, bound_box,
-                                             x_margin, y_margin, flip, uniform_grid, touch_edge)
+        ret_warrs = self.do_multi_power_fill(layer_id, tr_manager, top_lists, bound_box, x_margin, y_margin, flip, uniform_grid, draw_on_edge)
 
         # Reorganize return values
-        if sup_type.lower() == 'both':
-            top_vdd, top_vss = (ret_warrs[0], ret_warrs[1]) if not flip else (
-                ret_warrs[1], ret_warrs[0])
+        if sup_type.lower() == 'both': 
+            top_vdd, top_vss = (ret_warrs[0], ret_warrs[1]) if not flip else (ret_warrs[1], ret_warrs[0])
         elif sup_type.lower() == 'vss':
             top_vdd = []
             top_vss = ret_warrs[0]
@@ -2743,7 +2737,7 @@ class TemplateBase(DesignMaster):
     def do_multi_power_fill(self, layer_id: int, tr_manager: TrackManager,
                             sup_list: List[Union[WireArray, List[WireArray]]], bound_box: Optional[BBox] = None,
                             x_margin: int = 0, y_margin: int = 0, flip: bool = False, uniform_grid: bool = False
-                            , touch_edge: bool = True) -> List[List[WireArray]]:
+                            , draw_on_edge: bool = True) -> List[List[WireArray]]:
         """Draw power fill on the given layer. Accepts as many different supply nets as provided.
 
         Parameters
@@ -2764,7 +2758,7 @@ class TemplateBase(DesignMaster):
             draw power fill on a common grid instead of dense packing.
         flip : bool
             true to reverse order of power fill. Default is False.
-        touch_edge : bool
+        draw_on_edge : bool
             true to draw power fill to the edge of the bounding box. false to keep a margin of the preset value of track space width. Default is True.
 
         Returns
@@ -2791,25 +2785,22 @@ class TemplateBase(DesignMaster):
             cl, cu = bound_box.xl + fill_w2, bound_box.xh - fill_w2
             lower, upper = bound_box.yl, bound_box.yh
         sep_margin = tr_manager.get_sep(layer_id, ('sup', ''))
-        if touch_edge:
+        if draw_on_edge:
             tr_bot = self.grid.coord_to_track(layer_id, cl, mode=RoundMode.GREATER_EQ)
             tr_top = self.grid.coord_to_track(layer_id, cu, mode=RoundMode.LESS_EQ)
         else:
-            tr_bot = self.grid.coord_to_track(layer_id, cl, mode=RoundMode.GREATER) + sep_margin
-            tr_top = self.grid.coord_to_track(layer_id, cu, mode=RoundMode.LESS_EQ) - sep_margin
+            tr_bot = self.grid.coord_to_track(layer_id, cl, mode=RoundMode.GREATER) + sep_margin // 2
+            tr_top = self.grid.coord_to_track(layer_id, cu, mode=RoundMode.LESS) - sep_margin // 2
         trs = self.get_available_tracks(layer_id, tid_lo=tr_bot, tid_hi=tr_top, lower=lower, upper=upper,
                                         width=fill_width, sep=fill_space, sep_margin=sep_margin,
                                         uniform_grid=uniform_grid)
         all_warrs = [[] for _ in range(num_sups)]
         htr_sep = HalfInt.convert(fill_space).dbl_value
         if len(trs) < num_sups:
-            raise ValueError(
-                'Not enough available tracks to fill for all provided supplies')
+            raise ValueError('Not enough available tracks to fill for all provided supplies')
         for ncur, tr_idx in enumerate(trs):
-            warr = self.add_wires(layer_id, tr_idx, lower,
-                                  upper, width=fill_width)
-            _ncur = HalfInt.convert(
-                tr_idx).dbl_value // htr_sep if uniform_grid else ncur
+            warr = self.add_wires(layer_id, tr_idx, lower, upper, width=fill_width)
+            _ncur = HalfInt.convert(tr_idx).dbl_value // htr_sep if uniform_grid else ncur
             if not flip:
                 all_warrs[_ncur % num_sups].append(warr)
             else:


### PR DESCRIPTION
The original `do_power_fill` API calls `do_multi_power_fill`, which has
```tr_bot = self.grid.coord_to_track(layer_id, cl, mode=RoundMode.GREATER_EQ)```
This causes problem of generating a floating metal at the bottom of the bound_box that's not connected to the main power grid. This, when calling either `./gen_cell.sh $design.yml -v` to do on-the-fly LVS check or calling `./extract_cell.sh $design.yml`, leads to LVS failure because of the floating metal is virtual-connected to the supply.
Changed the roundmode to `RoundMode.GREATER` solves the problem.