### PR TITLE
Fix for SKILL function to modify schematics

### DIFF
--- a/run_scripts/start_bag_ICADV12d3.il
+++ b/run_scripts/start_bag_ICADV12d3.il
@@ -1360,10 +1360,8 @@ procedure( modify_schematic_content(sch_cv inst_list "gl")
                     when(cur_inst->name != rinst->name
                         cur_inst->name = rinst->name
                     )
-                    ; schReplaceProperty(list(cur_inst) "master" sprintf(nil "%s %s %s" rinst->lib_name
-                    ;                                                    rinst->cell_name cur_inst->viewName))
-                    schReplaceProperty(list(cur_inst) "libName" rinst->lib_name)
-                    schReplaceProperty(list(cur_inst) "cellName" rinst->cell_name)
+                    masterId = dbOpenCellViewByType(rinst->lib_name rinst->cell_name cur_inst->viewName)
+                    dbSet(cur_inst masterId "master")
                     ; set parameters
                     foreach( cdf_par cdfGetInstCDF(cur_inst)~>parameters
                         par_val = cadr(assoc(cdf_par->name rinst->params))


### PR DESCRIPTION
Previously discussed here: [PR44](https://github.com/ucb-art/bag/pull/44#issuecomment-2540422818)

Revised fix for the SKILL script to modify schematics, now using the `dbSet` function.
I noticed the previous fix did not work with hierarchical schematics (inv_chain). This seems to work now.
I tested this with Virtuoso 23.1 and 20.1, works fine for a few unit cases.