### PR TITLE
Sim & Sch features

### DIFF
--- a/src/bag/design/module.py
+++ b/src/bag/design/module.py
@@ -260,12 +260,20 @@ class Module(DesignMaster):
         """
         self._cv.set_param(key, val)
 
+    def post_design(self, **kwargs: Any) -> None:
+        """Optional function for hooks after 'design'
+        """
+        pass
+
     def finalize(self) -> None:
         """Finalize this master instance.
         """
         # invoke design function, excluding model_params
         args = dict((k, v) for k, v in self.params.items() if k != 'model_params')
         self.design(**args)
+
+        # Hook for optional actions
+        self.post_design(**args)
 
         # get set of children master keys
         for name, inst in self.instances.items():

--- a/src/bag/simulation/libpsf_simdata.py
+++ b/src/bag/simulation/libpsf_simdata.py
@@ -44,6 +44,9 @@ _ANA_TYPE_MAP = {
     'td.pss': 'pss_td',
     'fd.pss': 'pss_fd',
     'tran.pss': 'pss_tran',
+    'timedomain.pnoise': 'pnoise',
+    'pm.pnoise': 'pnoise',
+    'pac_timepoint': 'pac',
 }
 
 

--- a/src/bag/simulation/spectre.py
+++ b/src/bag/simulation/spectre.py
@@ -25,7 +25,7 @@ import time
 from pathlib import Path
 
 from pybag.enum import DesignOutput
-from pybag.core import get_cdba_name_bits
+from pybag.core import get_cdba_name_bits, convert_cdba_name_bit
 
 from ..math import float_to_si_string
 from ..io.file import read_yaml, open_file, is_valid_file, read_file
@@ -511,9 +511,9 @@ def _write_analysis(lines: List[str], sim_env: str, ana: AnalysisInfo, precision
                     has_ic: bool) -> List[str]:
     cur_line = f'__{ana.name}__{sim_env}__'
     if hasattr(ana, 'p_port') and ana.p_port:
-        cur_line += f' {ana.p_port}'
+        cur_line += f' {convert_cdba_name_bit(ana.p_port, DesignOutput.SPECTRE)}'
     if hasattr(ana, 'n_port') and ana.n_port:
-        cur_line += f' {ana.n_port}'
+        cur_line += f' {convert_cdba_name_bit(ana.n_port, DesignOutput.SPECTRE)}'
     cur_line += f' {ana.name}'
 
     if isinstance(ana, AnalysisTran):
@@ -575,9 +575,13 @@ def _write_analysis(lines: List[str], sim_env: str, ana: AnalysisInfo, precision
     if isinstance(ana, AnalysisPNoise):
         if ana.measurement:
             for idx, event in enumerate(ana.measurement):
-                cur_line = f'pm{idx} jitterevent trigger=[{event.trig_p} {event.trig_n}] ' \
+                trig_p = convert_cdba_name_bit(event.trig_p, DesignOutput.SPECTRE)
+                trig_n = convert_cdba_name_bit(event.trig_n, DesignOutput.SPECTRE)
+                targ_p = convert_cdba_name_bit(event.targ_p, DesignOutput.SPECTRE)
+                targ_n = convert_cdba_name_bit(event.targ_n, DesignOutput.SPECTRE)
+                cur_line = f'pm{idx} jitterevent trigger=[{trig_p} {trig_n}] ' \
                            f'triggerthresh={event.triggerthresh} triggernum={event.triggernum} ' \
-                           f'triggerdir={event.triggerdir} target=[{event.targ_p} {event.targ_n}]'
+                           f'triggerdir={event.triggerdir} target=[{targ_p} {targ_n}]'
                 jitter_event.append(cur_line)
     return jitter_event
 

--- a/src/bag/simulation/srr.py
+++ b/src/bag/simulation/srr.py
@@ -50,6 +50,7 @@ _ANA_TYPE_MAP = {
     'fd.pss': 'pss_fd',
     'tran.pss': 'pss_tran',
     'timedomain.pnoise': 'pnoise',
+    'pm.pnoise': 'pnoise',
     'pac_timepoint': 'pac',
 }
 


### PR DESCRIPTION
- Adding `convert_cdba_name_bit` to pnoise port setup.
- Additional pnoise analysis definitions
- `post_design` hook for extending the `Module` subclass

Name prefix and suffix were added in a separate PR in the history.
pnoise addition for libpsf is added. Nutbin will be a support feature in the future, since Ngspice doesn't support pnoise. Default to libpsf.

This is part of breaking up PR #34.