### PR TITLE
Layout features

### DIFF
--- a/src/bag/layout/template.py
+++ b/src/bag/layout/template.py
@@ -3031,7 +3031,13 @@ class TemplateBase(DesignMaster):
                     _num = num_wires_p
                 else:
                     _num = len(coord_list_p)
-                    _tidx_list = [self.grid.coord_to_track(_layer, coord, RoundMode.NEAREST) for coord in coord_list_p]
+                    if alignment_p == 0:
+                        mode = RoundMode.NEAREST
+                    elif alignment_p == -1:
+                        mode = RoundMode.LESS_EQ
+                    else:
+                        mode = RoundMode.GREATER_EQ
+                    _tidx_list = [self.grid.coord_to_track(_layer, coord, mode) for coord in coord_list_p]
             else:
                 # Orthogonal direction
                 _tidx_list = [self.grid.coord_to_track(_layer, coord, RoundMode.NEAREST) for coord in coord_list_o]

--- a/src/bag/layout/template.py
+++ b/src/bag/layout/template.py
@@ -2875,12 +2875,18 @@ class TemplateBase(DesignMaster):
                           mlm_dict: Optional[Mapping[int, MinLenMode]] = None,
                           ret_warr_dict: Optional[Mapping[int, WireArray]] = None,
                           coord_list_p_override: Optional[Sequence[int]] = None,
-                          coord_list_o_override: Optional[Sequence[int]] = None, alternate_o: bool = False
-                          ) -> WireArray:
-        """Helper method to draw via stack and connections upto top layer, assuming connections can be on grid.
+                          coord_list_o_override: Optional[Sequence[int]] = None,
+                          alternate_o: bool = False, use_available_tracks: bool = False
+                          ) -> Union[WireArray, List[WireArray]]:
+        """Helper method to draw via stack and connections up to top layer, assuming connections can be on grid.
         Should work regardless of direction of top layer and bot layer.
 
-        This method supports equally spaced WireArrays only. Needs modification for non uniformly spaced WireArrays.
+        This method supports equally spaced WireArrays only. By default, it does NOT check for unused tracks.
+        To use non-uniformly spaced tracks or check for used tracks, use `use_available_tracks`.
+
+        Returns a WireArray (num >= 1) if `use_available_tracks == False`.
+        If `use_available_tracks`, if the length of the return list is 1, returns a single WireArray.
+        Otherwise, returns a full list.
 
         Parameters
         ----------
@@ -2889,7 +2895,7 @@ class TemplateBase(DesignMaster):
         warr: WireArray
             The bot_layer wire array that has to via up
         top_layer: int
-            The top_layer upto which stacked via has to go
+            The top_layer up to which stacked via has to go
         w_type: str
             The wire type, for querying widths from track manager
         alignment_p: int
@@ -2911,10 +2917,13 @@ class TemplateBase(DesignMaster):
             If coord_o_list is computed (i.e. coord_o_list_override is not used) then every other track is skipped
             for via spacing. Using alternate_o, we can choose which set of tracks is used and which is skipped.
             This is useful to avoid line end spacing issues when two adjacent wires require via stacks.
+        use_available_tracks: bool
+            If True, checks for and uses available (unused) tracks. This leads to non-uniformly spaced WireArrays,
+            so the return is a list. If False (default), available tracks are not checked, so collisions can happen.
 
         Returns
         -------
-        top_warr: WireArray
+        top_warr: Union[WireArray, List[WireArray]]
             The top_layer warr after via stacking all the way up
         """
         if ret_warr_dict is None:
@@ -2940,19 +2949,38 @@ class TemplateBase(DesignMaster):
         top_dir = self.grid.get_direction(top_layer)
         top_layer_o = top_layer - 1 if bot_dir == top_dir else top_layer
 
+        # Get orthogonal bounds, for finding available tracks
+        if self.grid.get_direction(bot_layer) == Orient2D.x:
+            _l, _u = warr.bound_box.yl, warr.bound_box.yh
+        else:
+            _l, _u = warr.bound_box.xl, warr.bound_box.xh
+
         if coord_list_o_override is None:
             tidx_l = self.grid.coord_to_track(top_layer_o, warr.lower, RoundMode.GREATER_EQ)
             tidx_r = self.grid.coord_to_track(top_layer_o, warr.upper, RoundMode.LESS_EQ)
-            # Divide by 2 for via separation
-            num_wires_o = tr_manager.get_num_wires_between(top_layer_o, w_type, tidx_l, w_type, tidx_r, w_type) + 2
-            num_wires_o = max(-(- num_wires_o // 2), 1)
-            if num_wires_o == 1:
-                tidx_list_o = [self.grid.coord_to_track(top_layer_o, warr.middle, RoundMode.NEAREST)]
-            else:
-                tidx_list_o = tr_manager.spread_wires(top_layer_o, [w_type] * (2 * num_wires_o - 1), tidx_l, tidx_r,
-                                                      (w_type, w_type), alignment=alignment_o)
-                tidx_list_o = tidx_list_o[1::2] if alternate_o else tidx_list_o[0::2]
+            if use_available_tracks:
+                w_mid = tr_manager.get_width(top_layer_o, w_type)
+                sp_mid = tr_manager.get_sep(top_layer_o, (w_type, w_type))
+                tidx_list_o = self.get_available_tracks(top_layer_o, tidx_l, tidx_r, _l, _u, w_mid, sp_mid, True)
                 num_wires_o = len(tidx_list_o)
+                num_wires_o = max(-(- num_wires_o // 2), 1)
+                if num_wires_o == 1:
+                    tidx_list_o = [self.grid.coord_to_track(top_layer_o, warr.middle, RoundMode.NEAREST)]
+                else:
+                    tidx_list_o = tidx_list_o[1::2] if alternate_o else tidx_list_o[0::2]
+                    num_wires_o = len(tidx_list_o)
+            else:
+                # Evenly space wires
+                num_wires_o = tr_manager.get_num_wires_between(top_layer_o, w_type, tidx_l, w_type, tidx_r, w_type) + 2
+                # Divide by 2 for via separation
+                num_wires_o = max(-(- num_wires_o // 2), 1)
+                if num_wires_o == 1:
+                    tidx_list_o = [self.grid.coord_to_track(top_layer_o, warr.middle, RoundMode.NEAREST)]
+                else:
+                    tidx_list_o = tr_manager.spread_wires(top_layer_o, [w_type] * (2 * num_wires_o - 1), tidx_l, tidx_r,
+                                                          (w_type, w_type), alignment=alignment_o)
+                    tidx_list_o = tidx_list_o[1::2] if alternate_o else tidx_list_o[0::2]
+                    num_wires_o = len(tidx_list_o)
             # need to compute coord_list for conversion to tidx in layers which are same direction as top_layer_o
             coord_list_o = [self.grid.track_to_coord(top_layer_o, tidx) for tidx in tidx_list_o]
         else:
@@ -3000,14 +3028,38 @@ class TemplateBase(DesignMaster):
                     _num = len(coord_list_p)
                     _tidx_list = [self.grid.coord_to_track(_layer, coord, RoundMode.NEAREST) for coord in coord_list_p]
             else:
+                # Orthogonal direction
                 _tidx_list = [self.grid.coord_to_track(_layer, coord, RoundMode.NEAREST) for coord in coord_list_o]
-                _num = num_wires_o
-            sep = _tidx_list[1] - _tidx_list[0] if _num > 1 else 0
-            # TODO: support non-uniformly spaced list of WireArrays
-            warr = self.connect_to_tracks(warr, TrackID(_layer, _tidx_list[0], _w, num=_num, pitch=sep),
-                                          min_len_mode=_mlm)
+
+                # Check that the track is available on this layer
+                def _check(tidx):
+                    _list = self.get_available_tracks(_layer, tidx, tidx, _l, _u, _w, include_last=True)
+                    return tidx in _list
+
+                if use_available_tracks:
+                    # TODO: More verification of half tracks required
+                    if len(_tidx_list) > 1:
+                        _tidx_list = [tidx for tidx in _tidx_list if _check(tidx)]
+                _num = len(_tidx_list)
+
+            if _num < 1:
+                raise RuntimeError("connect_via_stack: No vias found!")
+
+            if use_available_tracks:
+                tid_list = [TrackID(_layer, _tidx, _w) for _tidx in _tidx_list]
+                warr_list = [self.connect_to_tracks(warr, _tid, min_len_mode=_mlm) for _tid in tid_list]
+                warr = self.connect_wires(warr_list)
+                if len(warr) == 1:
+                    warr = warr[0]
+            else:
+                # Uniformly spaced
+                sep = _tidx_list[1] - _tidx_list[0] if _num > 1 else 0
+                warr = self.connect_to_tracks(warr, TrackID(_layer, _tidx_list[0], _w, num=_num, pitch=sep),
+                                              min_len_mode=_mlm)
             ret_warr_dict[_layer] = warr
 
+        if not warr:
+            raise RuntimeError("connect_via_stack: No wires drawn!")
         return warr
 
     @property

--- a/src/bag/layout/template.py
+++ b/src/bag/layout/template.py
@@ -2876,7 +2876,8 @@ class TemplateBase(DesignMaster):
                           ret_warr_dict: Optional[Mapping[int, WireArray]] = None,
                           coord_list_p_override: Optional[Sequence[int]] = None,
                           coord_list_o_override: Optional[Sequence[int]] = None,
-                          alternate_o: bool = False, use_available_tracks: bool = False
+                          alternate_o: bool = False, use_available_tracks: bool = False,
+                          use_all_tracks: bool = False,
                           ) -> Union[WireArray, List[WireArray]]:
         """Helper method to draw via stack and connections up to top layer, assuming connections can be on grid.
         Should work regardless of direction of top layer and bot layer.
@@ -2920,6 +2921,8 @@ class TemplateBase(DesignMaster):
         use_available_tracks: bool
             If True, checks for and uses available (unused) tracks. This leads to non-uniformly spaced WireArrays,
             so the return is a list. If False (default), available tracks are not checked, so collisions can happen.
+        use_all_tracks: bool
+            If True, uses all tracks instead of alternating. Default is False for via spacing.
 
         Returns
         -------
@@ -2967,7 +2970,8 @@ class TemplateBase(DesignMaster):
                 if num_wires_o == 1:
                     tidx_list_o = [self.grid.coord_to_track(top_layer_o, warr.middle, RoundMode.NEAREST)]
                 else:
-                    tidx_list_o = tidx_list_o[1::2] if alternate_o else tidx_list_o[0::2]
+                    if not use_all_tracks:
+                        tidx_list_o = tidx_list_o[1::2] if alternate_o else tidx_list_o[0::2]
                     num_wires_o = len(tidx_list_o)
             else:
                 # Evenly space wires
@@ -2979,7 +2983,8 @@ class TemplateBase(DesignMaster):
                 else:
                     tidx_list_o = tr_manager.spread_wires(top_layer_o, [w_type] * (2 * num_wires_o - 1), tidx_l, tidx_r,
                                                           (w_type, w_type), alignment=alignment_o)
-                    tidx_list_o = tidx_list_o[1::2] if alternate_o else tidx_list_o[0::2]
+                    if not use_all_tracks:
+                        tidx_list_o = tidx_list_o[1::2] if alternate_o else tidx_list_o[0::2]
                     num_wires_o = len(tidx_list_o)
             # need to compute coord_list for conversion to tidx in layers which are same direction as top_layer_o
             coord_list_o = [self.grid.track_to_coord(top_layer_o, tidx) for tidx in tidx_list_o]


### PR DESCRIPTION
- `connect_via_stack`: `use_available_tracks` option to check for available tracks (negative to existing tracks)
- `connect_via_stack`: `use_all_tracks` options to bypass the default every-other behavior.
- `get_shield_tracks`: width feature
- `connect_differential_wires`: fix length matching
- `do_power_fill`: text fixes + error case
- `connect_via_stack`: use `alignment_p` to set round mode for auto fill.

This PR is part of breaking up PR #34.